### PR TITLE
Avoid XMLDB file error: PATH attribute does not match file directory

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <XMLDB PATH="question/type/kprime/db" VERSION="20140924"
-	COMMENT="XMLDB file for Moodle question/type/matrix" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	COMMENT="XMLDB file for Moodle question/type/kprime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd">
 	<TABLES>
 		<TABLE NAME="qtype_kprime_options" COMMENT="Contains info about kprime questions">


### PR DESCRIPTION
Hi Amr

A comment in the db/install.xml field is not correct.

Please consider this pull request.

Best,
Luca