### PR TITLE
Releasing version 2.2 for Moodle 3.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# moodle-qtype_kprime v 2018120500 for moodle 2.6+ (2016/04/26)
+# moodle-qtype_kprime v 2.2 for Moodle 3.4+ (2019031800, 2019/03/18)
+
+A four option multiple true-false question type for moodle, as introduced by Krebs (1997). Kprime questions consist of an item stem and four corresponding statements or options. For each option students have to decide whether it is "true" or "false". Three different scoring methods are available: “Kprime”, where the student receives one point if all responses are correct, half a point if all save one response are correct, and zero points otherwise; “Kprime 1/0”, where the student receives one point if all responses are correct, and zero points otherwise; and “subpoints”, where the student is awarded subpoints for each correct response.

--- a/version.php
+++ b/version.php
@@ -26,4 +26,4 @@ $plugin->component = 'qtype_kprime';
 $plugin->version = 2019031800;
 $plugin->requires = 2013111904; // Moodle >=2.6.4.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '1.7 for Moodle 2.6+';
+$plugin->release = '2.2 for Moodle 3.4+';


### PR DESCRIPTION
Dear qtype_kprime team.
Thanks for your terrific work!
It would be great if you could synchronize your somewhat exotic/intransparent version info to be the same all over the Moodle plugins directory, README.md, version.php and Git tags.
This branch gives an example of it. Now you would just have to add the 2.2 tag in case of a merge and release. Of course content of README.md is just a proposal. I just took the description of the plugin.
Best,
Luca