### PR TITLE
Fixing coding style warnings and errors.

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:9.6
+        image: postgres:10.0
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -27,8 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4']
-        moodle-branch: ['MOODLE_311_STABLE']
+        php: ['7.4', '7.3']
+        moodle-branch: ['MOODLE_400_STABLE', 'master']
         database: [pgsql, mariadb]
 
     steps:

--- a/backup/moodle2/backup_qtype_kprime_plugin.class.php
+++ b/backup/moodle2/backup_qtype_kprime_plugin.class.php
@@ -26,8 +26,6 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Provides the backup for qtype_kprime questions.
  */

--- a/backup/moodle2/restore_qtype_kprime_plugin.class.php
+++ b/backup/moodle2/restore_qtype_kprime_plugin.class.php
@@ -27,8 +27,6 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Restore plugin class that provides the necessary information needed to restore one qtype_kprime plugin.
  */

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -29,8 +29,6 @@
 
 namespace qtype_kprime\output;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Mock class for get_content.
  *

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -29,8 +29,6 @@
 
 namespace qtype_kprime\privacy;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Privacy Subsystem for qtype_kprime implementing null_provider.
  *

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -27,8 +27,6 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Upgrade code for the kprime question type.
  *

--- a/edit_kprime_form.php
+++ b/edit_kprime_form.php
@@ -8,11 +8,11 @@
 //
 // Moodle is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle. If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
  * qtype_skprimeediting form.
@@ -28,9 +28,9 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-require_once ($CFG->dirroot . '/question/type/edit_question_form.php');
-require_once ($CFG->dirroot . '/question/type/kprime/lib.php');
-require_once ($CFG->dirroot . '/question/engine/bank.php');
+require_once($CFG->dirroot . '/question/type/edit_question_form.php');
+require_once($CFG->dirroot . '/question/type/kprime/lib.php');
+require_once($CFG->dirroot . '/question/engine/bank.php');
 
 /**
  * qtype_kprime editing form definition.
@@ -113,7 +113,8 @@ class qtype_kprime_edit_form extends question_edit_form {
             }
         }
 
-        if (class_exists('qbank_editquestion\\editquestion_helper') && !empty($this->question->id) && !$this->question->beingcopied) {
+        if (class_exists('qbank_editquestion\\editquestion_helper') &&
+            !empty($this->question->id) && !$this->question->beingcopied) {
             // Add extra information from plugins when editing a question (e.g.: Authors, version control and usage).
             $functionname = 'edit_form_display';
             $questiondata = [];
@@ -194,7 +195,8 @@ class qtype_kprime_edit_form extends question_edit_form {
 
         $this->add_action_buttons(true, get_string('savechanges'));
 
-        if ((!empty($this->question->id)) && (!($this->question->formoptions->canedit || $this->question->formoptions->cansaveasnew))) {
+        if ((!empty($this->question->id)) && (!($this->question->formoptions->canedit ||
+            $this->question->formoptions->cansaveasnew))) {
             $mform->hardFreezeAllVisibleExcept(array('categorymoveto', 'buttonar', 'currentgrp'));
         }
     }
@@ -232,16 +234,17 @@ class qtype_kprime_edit_form extends question_edit_form {
         $attributes = array();
         $scoringbuttons = array();
 
-        $scoringbuttons[] = &$mform->createElement('radio', 'scoringmethod', '', get_string('scoringkprime', 'qtype_kprime'),
-                                                'kprime', $attributes);
+        $scoringbuttons[] = &$mform->createElement('radio', 'scoringmethod', '',
+            get_string('scoringkprime', 'qtype_kprime'), 'kprime', $attributes);
 
-        $scoringbuttons[] = &$mform->createElement('radio', 'scoringmethod', '', get_string('scoringkprimeonezero', 'qtype_kprime'),
-                                                'kprimeonezero', $attributes);
+        $scoringbuttons[] = &$mform->createElement('radio', 'scoringmethod', '',
+            get_string('scoringkprimeonezero', 'qtype_kprime'), 'kprimeonezero', $attributes);
 
-        $scoringbuttons[] = &$mform->createElement('radio', 'scoringmethod', '', get_string('scoringsubpoints', 'qtype_kprime'),
-                                                'subpoints', $attributes);
+        $scoringbuttons[] = &$mform->createElement('radio', 'scoringmethod', '',
+            get_string('scoringsubpoints', 'qtype_kprime'), 'subpoints', $attributes);
 
-        $mform->addGroup($scoringbuttons, 'radiogroupscoring', get_string('scoringmethod', 'qtype_kprime'), array(' <br/> '), false);
+        $mform->addGroup($scoringbuttons, 'radiogroupscoring', get_string('scoringmethod', 'qtype_kprime'), array(' <br/> '),
+            false);
 
         $mform->addHelpButton('radiogroupscoring', 'scoringmethod', 'qtype_kprime');
         $mform->setDefault('scoringmethod', 'kprime');

--- a/grading/qtype_kprime_grading.class.php
+++ b/grading/qtype_kprime_grading.class.php
@@ -27,8 +27,6 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Provides grading functionality
  *

--- a/lib.php
+++ b/lib.php
@@ -27,8 +27,6 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 define('QTYPE_KPRIME_NUMBER_OF_OPTIONS', 4);
 define('QTYPE_KPRIME_NUMBER_OF_RESPONSES', 2);
 

--- a/mobile/kprime.js
+++ b/mobile/kprime.js
@@ -52,7 +52,7 @@ var result = {
         var options = [];
         var divs = answeroptions.querySelectorAll('tr');
 
-        divs.forEach(function(d, i) {
+        divs.forEach(function(d) {
 
             var text = d.querySelector('span.optiontext');
             text = (text !== null) ? text.innerHTML : null;
@@ -63,7 +63,7 @@ var result = {
             var disabled = d.querySelector('input');
             disabled = (disabled !== null) ? (disabled.hasAttribute('disabled') ? true : false) : false;
 
-            var feedback = d.querySelector('div')
+            var feedback = d.querySelector('div');
             feedback = feedback !== null ? feedback.innerHTML : '';
 
             var qclass = d.getAttribute('class');

--- a/question.php
+++ b/question.php
@@ -27,8 +27,6 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Represents a qtype_kprime question.
  *

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -27,7 +27,10 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace qtype_kprime;
+
 defined('MOODLE_INTERNAL') || die();
+
 global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 
@@ -38,23 +41,23 @@ require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @group       qtype_kprime
  */
-class qtype_kprime_question_test extends advanced_testcase {
+class question_test extends \advanced_testcase {
 
     /**
      * Makes a qtype_sc question.
      * @return qtype_kprime
      */
     public function make_a_kprime_question() {
-        question_bank::load_question_definition_classes('kprime');
-        $kprime = new qtype_kprime_question();
-        test_question_maker::initialise_a_question($kprime);
+        \question_bank::load_question_definition_classes('kprime');
+        $kprime = new \qtype_kprime_question();
+        \test_question_maker::initialise_a_question($kprime);
         $kprime->name = 'Kprime Question';
         $kprime->idnumber = 1;
         $kprime->questiontext = 'the right choices are option 1 and option 2';
         $kprime->generalfeedback = 'You should do this and that';
-        $kprime->qtype = question_bank::get_qtype('kprime');
+        $kprime->qtype = \question_bank::get_qtype('kprime');
         $kprime->status = \core_question\local\bank\question_version_status::QUESTION_STATUS_READY;
-        $kprime->options = new stdClass();
+        $kprime->options = new \stdClass();
         $kprime->shuffleanswers = 0;
         $kprime->answernumbering = 'abc';
         $kprime->scoringmethod = "subpoints";
@@ -140,6 +143,8 @@ class qtype_kprime_question_test extends advanced_testcase {
 
     /**
      * Test get_expected_data
+     *
+     * @covers ::get_expected_data
      */
     public function test_get_expected_data() {
         $question = $this->make_a_kprime_question();
@@ -150,6 +155,8 @@ class qtype_kprime_question_test extends advanced_testcase {
 
     /**
      * Test is_complete_response
+     *
+     * @covers ::is_complete_response
      */
     public function test_is_complete_response() {
         $question = $this->make_a_kprime_question();
@@ -168,6 +175,8 @@ class qtype_kprime_question_test extends advanced_testcase {
 
     /**
      * Test is_gradable_response
+     *
+     * @covers ::is_gradable_response
      */
     public function test_is_gradable_response() {
         $question = $this->make_a_kprime_question();
@@ -208,20 +217,25 @@ class qtype_kprime_question_test extends advanced_testcase {
 
     /**
      * Test get_order
+     *
+     * @covers ::get_order
      */
     public function test_get_order() {
         $question = $this->make_a_kprime_question();
         $question->shuffleanswers = 1;
-        $question->start_attempt(new question_attempt_step(), 1);
-        $this->assertEquals( $question->order, $question->get_order(test_question_maker::get_a_qa($question)));
+        $question->start_attempt(new \question_attempt_step(), 1);
+        $this->assertEquals( $question->order, $question->get_order(\test_question_maker::get_a_qa($question)));
         unset($question);
         $question = $this->make_a_kprime_question();
-        $question->start_attempt(new question_attempt_step(), 1);
-        $this->assertEquals( array(0 => 1, 1 => 2, 2 => 3, 3 => 4), $question->get_order(test_question_maker::get_a_qa($question)));
+        $question->start_attempt(new \question_attempt_step(), 1);
+        $this->assertEquals( array(0 => 1, 1 => 2, 2 => 3, 3 => 4),
+            $question->get_order(\test_question_maker::get_a_qa($question)));
     }
 
     /**
      * Test is_correct
+     *
+     * @covers ::is_correct
      */
     public function test_is_correct() {
         $question = $this->make_a_kprime_question();
@@ -237,10 +251,12 @@ class qtype_kprime_question_test extends advanced_testcase {
 
     /**
      * Test is_same_response
+     *
+     * @covers ::is_same_response
      */
     public function test_is_same_response() {
         $question = $this->make_a_kprime_question();
-        $question->start_attempt(new question_attempt_step(), 1);
+        $question->start_attempt(new \question_attempt_step(), 1);
         $this->assertTrue($question->is_same_response(
             array(),
             array()));
@@ -272,46 +288,54 @@ class qtype_kprime_question_test extends advanced_testcase {
 
     /**
      * Test grading
+     *
+     * @covers ::get_correct_response
      */
     public function test_grading() {
         $question = $this->make_a_kprime_question();
-        $question->start_attempt(new question_attempt_step(), 1);
+        $question->start_attempt(new \question_attempt_step(), 1);
         $this->assertEquals(array('option0' => '1', 'option1' => '1', 'option2' => '2', 'option3' => '2'),
         $question->get_correct_response());
     }
 
     /**
      * Test summarise_response
+     *
+     * @covers ::summarise_response
      */
     public function test_summarise_response() {
         $question = $this->make_a_kprime_question();
-        $question->start_attempt(new question_attempt_step(), 1);
+        $question->start_attempt(new \question_attempt_step(), 1);
         $summary = $question->summarise_response(array('option0' => '1', 'option1' => '1', 'option2' => '2', 'option3' => '2'),
-        test_question_maker::get_a_qa($question));
+        \test_question_maker::get_a_qa($question));
         $this->assertEquals('option text 1: True; option text 2: True; option text 3: False; option text 4: False', $summary);
     }
 
     /**
      * Test classify_response
+     *
+     * @covers ::classify_response
      */
     public function test_classify_response() {
         $question = $this->make_a_kprime_question();
-        $question->start_attempt(new question_attempt_step(), 1);
+        $question->start_attempt(new \question_attempt_step(), 1);
 
-        $this->assertEquals(array('1' => new question_classified_response(1, 'True', 0.25),
-            '2' => new question_classified_response(1, 'True', 0.25),
-            '3' => new question_classified_response(2, 'False', 0.25),
-            '4' => new question_classified_response(2, 'False', 0.25)),
+        $this->assertEquals(array('1' => new \question_classified_response(1, 'True', 0.25),
+            '2' => new \question_classified_response(1, 'True', 0.25),
+            '3' => new \question_classified_response(2, 'False', 0.25),
+            '4' => new \question_classified_response(2, 'False', 0.25)),
             $question->classify_response(array('option0' => '1', 'option1' => '1', 'option2' => '2', 'option3' => '2')));
-        $this->assertEquals(array('1' => question_classified_response::no_response(),
-            '2' => question_classified_response::no_response(),
-            '3' => question_classified_response::no_response(),
-            '4' => question_classified_response::no_response()),
+        $this->assertEquals(array('1' => \question_classified_response::no_response(),
+            '2' => \question_classified_response::no_response(),
+            '3' => \question_classified_response::no_response(),
+            '4' => \question_classified_response::no_response()),
             $question->classify_response(array()));
     }
 
     /**
      * Test make_html_inline
+     *
+     * @covers ::make_html_inline
      */
     public function test_make_html_inline() {
         $question = $this->make_a_kprime_question();
@@ -327,20 +351,24 @@ class qtype_kprime_question_test extends advanced_testcase {
 
     /**
      * Test get_hint
+     *
+     * @covers ::get_hint
      */
     public function test_get_hint() {
         $question = $this->make_a_kprime_question();
-        $question->start_attempt(new question_attempt_step(), 1);
-        $this->assertEquals('Hint 1', $question->get_hint(0, test_question_maker::get_a_qa($question))->hint);
-        $this->assertEquals('Hint 2', $question->get_hint(1, test_question_maker::get_a_qa($question))->hint);
+        $question->start_attempt(new \question_attempt_step(), 1);
+        $this->assertEquals('Hint 1', $question->get_hint(0, \test_question_maker::get_a_qa($question))->hint);
+        $this->assertEquals('Hint 2', $question->get_hint(1, \test_question_maker::get_a_qa($question))->hint);
     }
 
     /**
      * Test compute_final_grade (subpoints)
+     *
+     * @covers ::compute_final_grade
      */
     public function test_compute_final_grade_subpoints() {
         $question = $this->make_a_kprime_question();
-        $question->start_attempt(new question_attempt_step(), 1);
+        $question->start_attempt(new \question_attempt_step(), 1);
         $this->assertEquals('1.0', $question->compute_final_grade(array(
             0 => array('option0' => '1', 'option1' => '1', 'option2' => '2', 'option3' => '2')),
             1));
@@ -370,11 +398,13 @@ class qtype_kprime_question_test extends advanced_testcase {
 
     /**
      * Test compute_final_grade (kprime)
+     *
+     * @covers ::compute_final_grade
      */
     public function test_compute_final_grade_kprime() {
         $question = $this->make_a_kprime_question();
         $question->scoringmethod = 'kprime';
-        $question->start_attempt(new question_attempt_step(), 1);
+        $question->start_attempt(new \question_attempt_step(), 1);
         $this->assertEquals('1.0', $question->compute_final_grade(array(
             0 => array('option0' => '1', 'option1' => '1', 'option2' => '2', 'option3' => '2')),
             1));
@@ -428,11 +458,13 @@ class qtype_kprime_question_test extends advanced_testcase {
 
     /**
      * Test compute_final_grade (kprimeonezero)
+     *
+     * @covers ::compute_final_grade
      */
     public function test_compute_final_grade_kprimeonezero() {
         $question = $this->make_a_kprime_question();
         $question->scoringmethod = 'kprimeonezero';
-        $question->start_attempt(new question_attempt_step(), 1);
+        $question->start_attempt(new \question_attempt_step(), 1);
         $this->assertEquals('1.0', $question->compute_final_grade(array(
             0 => array('option0' => '1', 'option1' => '1', 'option2' => '2', 'option3' => '2')),
             1));
@@ -462,10 +494,12 @@ class qtype_kprime_question_test extends advanced_testcase {
 
     /**
      * Test grade_response (subpoints)
+     *
+     * @covers ::grade_response
      */
     public function test_grade_response_subpoints() {
         $question = $this->make_a_kprime_question();
-        $question->start_attempt(new question_attempt_step(), 1);
+        $question->start_attempt(new \question_attempt_step(), 1);
         $this->assertEquals(
             "1.0", $question->grade_response(array('option0' => '1', 'option1' => '1', 'option2' => '2', 'option3' => '2'))[0]);
         $this->assertEquals(
@@ -478,11 +512,13 @@ class qtype_kprime_question_test extends advanced_testcase {
 
     /**
      * Test grade_response (kprime)
+     *
+     * @covers ::grade_response
      */
     public function test_grade_response_kprime() {
         $question = $this->make_a_kprime_question();
         $question->scoringmethod = 'kprime';
-        $question->start_attempt(new question_attempt_step(), 1);
+        $question->start_attempt(new \question_attempt_step(), 1);
         $this->assertEquals(
             "1.0", $question->grade_response(array('option0' => '1', 'option1' => '1', 'option2' => '2', 'option3' => '2'))[0]);
         $this->assertEquals(
@@ -497,11 +533,13 @@ class qtype_kprime_question_test extends advanced_testcase {
 
     /**
      * Test grade_response (kprimeonezero)
+     *
+     * @covers ::grade_response
      */
     public function test_grade_response_kprimeonezero() {
         $question = $this->make_a_kprime_question();
         $question->scoringmethod = 'kprimeonezero';
-        $question->start_attempt(new question_attempt_step(), 1);
+        $question->start_attempt(new \question_attempt_step(), 1);
         $this->assertEquals(
             "1.0", $question->grade_response(array('option0' => '1', 'option1' => '1', 'option2' => '2', 'option3' => '2'))[0]);
         $this->assertEquals(

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -27,7 +27,10 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace qtype_kprime;
+
 defined('MOODLE_INTERNAL') || die();
+
 global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/question/type/kprime/questiontype.php');
@@ -41,19 +44,24 @@ require_once($CFG->dirroot . '/question/type/kprime/edit_kprime_form.php');
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @group       qtype_kprime
  */
-class qtype_kprime_test extends advanced_testcase {
+class questiontype_test extends \advanced_testcase {
 
     /** @var object qtype */
     protected $qtype;
 
     protected function setUp(): void {
-        $this->qtype = new qtype_kprime();
+        $this->qtype = new \qtype_kprime();
     }
 
     protected function tearDown(): void {
         $this->qtype = null;
     }
 
+    /**
+     * Test get_name
+     *
+     * @covers ::get_name()
+     */
     public function test_name() {
         $this->assertEquals($this->qtype->name(), 'kprime');
     }
@@ -61,10 +69,10 @@ class qtype_kprime_test extends advanced_testcase {
     /**
      * Get some test question data.
      * @return object the data to construct a question like
-     * {@see test_question_maker::make_question($questiondata)}.
+     * {@see \test_question_maker::make_question($questiondata)}.
      */
     protected function get_test_question_data() {
-        $qdata = new stdClass();
+        $qdata = new \stdClass();
         $qdata->id = 1;
         $qdata->idnumber = 1;
         $qdata->category = 1;
@@ -86,7 +94,7 @@ class qtype_kprime_test extends advanced_testcase {
         $qdata->timemodified = "1552376610";
         $qdata->createdby = 0;
         $qdata->modifiedby = 0;
-        $qdata->options = new stdClass();
+        $qdata->options = new \stdClass();
         $qdata->options->scoringmethod = "subpoints";
         $qdata->options->shuffleanswers = 0;
         $qdata->options->numberofrows = 4;
@@ -156,6 +164,8 @@ class qtype_kprime_test extends advanced_testcase {
 
     /**
      * Test can_analyse_responses
+     *
+     * @covers ::can_analyse_responses()
      */
     public function test_can_analyse_responses() {
         $this->assertTrue($this->qtype->can_analyse_responses());
@@ -163,6 +173,8 @@ class qtype_kprime_test extends advanced_testcase {
 
     /**
      * Test get_random_guess_score_kprime
+     *
+     * @covers ::get_random_guess_score()
      */
     public function test_get_random_guess_score_kprime() {
         $question = $this->get_test_question_data();
@@ -172,6 +184,8 @@ class qtype_kprime_test extends advanced_testcase {
 
     /**
      * Test get_random_guess_score_kprimeonezero
+     *
+     * @covers ::get_random_guess_score()
      */
     public function test_get_random_guess_score_kprimeonezero() {
         $question = $this->get_test_question_data();
@@ -181,6 +195,8 @@ class qtype_kprime_test extends advanced_testcase {
 
     /**
      * Test get_random_guess_score_subpoints
+     *
+     * @covers ::get_random_guess_score()
      */
     public function test_get_random_guess_score_subpoints() {
         $question = $this->get_test_question_data();
@@ -189,30 +205,32 @@ class qtype_kprime_test extends advanced_testcase {
 
     /**
      * Test get_possible_responses_subpoints
+     *
+     * @covers ::get_possible_responses()
      */
     public function test_get_possible_responses_subpoints() {
         $question = $this->get_test_question_data();
         $responses = $this->qtype->get_possible_responses($question);
         $this->assertEquals(array(
             1 => array(
-                1 => new question_possible_response('option text 1: True (Correct Response)', 0.25),
-                2 => new question_possible_response('option text 1: False', 0.0),
-                null => question_possible_response::no_response()
+                1 => new \question_possible_response('option text 1: True (Correct Response)', 0.25),
+                2 => new \question_possible_response('option text 1: False', 0.0),
+                null => \question_possible_response::no_response()
             ),
             2 => array (
-                1 => new question_possible_response('option text 2: True (Correct Response)', 0.25),
-                2 => new question_possible_response('option text 2: False', 0.0),
-                null => question_possible_response::no_response()
+                1 => new \question_possible_response('option text 2: True (Correct Response)', 0.25),
+                2 => new \question_possible_response('option text 2: False', 0.0),
+                null => \question_possible_response::no_response()
             ),
             3 => array(
-                1 => new question_possible_response('option text 3: True', 0.0),
-                2 => new question_possible_response('option text 3: False (Correct Response)', 0.25),
-                null => question_possible_response::no_response()
+                1 => new \question_possible_response('option text 3: True', 0.0),
+                2 => new \question_possible_response('option text 3: False (Correct Response)', 0.25),
+                null => \question_possible_response::no_response()
             ),
             4 => array (
-                1 => new question_possible_response('option text 4: True', 0.0),
-                2 => new question_possible_response('option text 4: False (Correct Response)', 0.25),
-                null => question_possible_response::no_response()
+                1 => new \question_possible_response('option text 4: True', 0.0),
+                2 => new \question_possible_response('option text 4: False (Correct Response)', 0.25),
+                null => \question_possible_response::no_response()
             )
         ), $this->qtype->get_possible_responses($question));
     }
@@ -228,17 +246,19 @@ class qtype_kprime_test extends advanced_testcase {
      * Test question saving
      * @dataProvider get_question_saving_which
      * @param string $which
+     *
+     * @covers ::save_question()
      */
     public function test_question_saving_question_one($which) {
         $this->resetAfterTest(true);
         $this->setAdminUser();
-        $questiondata = test_question_maker::get_question_data('kprime', $which);
-        $formdata = test_question_maker::get_question_form_data('kprime', $which);
+        $questiondata = \test_question_maker::get_question_data('kprime', $which);
+        $formdata = \test_question_maker::get_question_form_data('kprime', $which);
         $generator = $this->getDataGenerator()->get_plugin_generator('core_question');
         $cat = $generator->create_question_category(array());
         $formdata->category = "{$cat->id},{$cat->contextid}";
-        qtype_kprime_edit_form::mock_submit((array)$formdata);
-        $form = qtype_kprime_test_helper::get_question_editing_form($cat, $questiondata);
+        \qtype_kprime_edit_form::mock_submit((array)$formdata);
+        $form = \qtype_kprime_test_helper::get_question_editing_form($cat, $questiondata);
         $this->assertTrue($form->is_validated());
         $fromform = $form->get_data();
         $returnedfromsave = $this->qtype->save_question($questiondata, $fromform);
@@ -293,18 +313,20 @@ class qtype_kprime_test extends advanced_testcase {
 
     /**
      * Test get_question_options.
+     *
+     * @covers ::get_question_options()
      */
     public function test_get_question_options() {
         global $DB;
         $this->resetAfterTest(true);
         $this->setAdminUser();
-        $questiondata = test_question_maker::get_question_data('kprime', 'question_one');
-        $formdata = test_question_maker::get_question_form_data('kprime', 'question_two');
+        $questiondata = \test_question_maker::get_question_data('kprime', 'question_one');
+        $formdata = \test_question_maker::get_question_form_data('kprime', 'question_two');
         $generator = $this->getDataGenerator()->get_plugin_generator('core_question');
         $cat = $generator->create_question_category(array());
         $formdata->category = "{$cat->id},{$cat->contextid}";
-        qtype_kprime_edit_form::mock_submit((array)$formdata);
-        $form = qtype_kprime_test_helper::get_question_editing_form($cat, $questiondata);
+        \qtype_kprime_edit_form::mock_submit((array)$formdata);
+        $form = \qtype_kprime_test_helper::get_question_editing_form($cat, $questiondata);
         $this->assertTrue($form->is_validated());
         $fromform = $form->get_data();
         $returnedfromsave = $this->qtype->save_question($questiondata, $fromform);

--- a/tests/walkthrough_test.php
+++ b/tests/walkthrough_test.php
@@ -27,7 +27,10 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace qtype_kprime;
+
 defined('MOODLE_INTERNAL') || die();
+
 global $CFG;
 require_once($CFG->dirroot . '/question/engine/lib.php');
 require_once($CFG->dirroot . '/question/type/kprime/tests/helper.php');
@@ -40,7 +43,7 @@ require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @group       qtype_kprime
  */
-class qtype_kprime_walkthrough_test extends qbehaviour_walkthrough_test_base {
+class walkthrough_test extends \qbehaviour_walkthrough_test_base {
 
     /**
      * (non-PHPdoc)
@@ -62,15 +65,15 @@ class qtype_kprime_walkthrough_test extends qbehaviour_walkthrough_test_base {
      * @return qtype_kprime
      */
     public function make_a_kprime_question() {
-        question_bank::load_question_definition_classes('kprime');
-        $kprime = new qtype_kprime_question();
-        test_question_maker::initialise_a_question($kprime);
+        \question_bank::load_question_definition_classes('kprime');
+        $kprime = new \qtype_kprime_question();
+        \test_question_maker::initialise_a_question($kprime);
         $kprime->name = 'Kprime Question';
         $kprime->idnumber = 1;
         $kprime->questiontext = 'the right choices are option 1 and option 2';
         $kprime->generalfeedback = 'You should do this and that';
-        $kprime->qtype = question_bank::get_qtype('kprime');
-        $kprime->options = new stdClass();
+        $kprime->qtype = \question_bank::get_qtype('kprime');
+        $kprime->options = new \stdClass();
         $kprime->options->shuffleanswers = 1;
         $kprime->status = \core_question\local\bank\question_version_status::QUESTION_STATUS_READY;
         $kprime->answernumbering = 'abc';
@@ -140,12 +143,14 @@ class qtype_kprime_walkthrough_test extends qbehaviour_walkthrough_test_base {
 
     /**
      * Test deferredfeedback_feedback_kprime
+     *
+     * @covers ::question_behaviours
      */
     public function test_deferredfeedback_feedback_kprime() {
         $kprime = $this->make_a_kprime_question();
         $this->start_attempt_at_question($kprime, 'deferredfeedback', 1);
         $this->process_submission(array("option0" => 1, "option1" => 1, "option2" => 2, "option3" => 2));
-        $this->check_current_state(question_state::$complete);
+        $this->check_current_state(\question_state::$complete);
         $this->check_current_mark(null);
         $this->check_current_output(
             $this->get_contains_kprime_radio_expectation(0, 1, true, true),
@@ -159,7 +164,7 @@ class qtype_kprime_walkthrough_test extends qbehaviour_walkthrough_test_base {
             $this->get_does_not_contain_correctness_expectation(),
             $this->get_does_not_contain_feedback_expectation());
         $this->quba->finish_all_questions();
-        $this->check_current_state(question_state::$gradedright);
+        $this->check_current_state(\question_state::$gradedright);
         $this->check_current_mark(1);
         $this->check_current_output(
             $this->get_contains_kprime_radio_expectation(0, 1, false, true),
@@ -167,10 +172,10 @@ class qtype_kprime_walkthrough_test extends qbehaviour_walkthrough_test_base {
             $this->get_contains_kprime_radio_expectation(2, 2, false, true),
             $this->get_contains_kprime_radio_expectation(3, 2, false, true),
             $this->get_contains_correct_expectation(),
-            new question_pattern_expectation('/name=\".*1_option0\".*value=\"1\".*checked=\"checked\"/'),
-            new question_pattern_expectation('/name=\".*1_option1\".*value=\"1\".*checked=\"checked\"/'),
-            new question_pattern_expectation('/name=\".*1_option2\".*value=\"2\".*checked=\"checked\"/'),
-            new question_pattern_expectation('/name=\".*1_option3\".*value=\"2\".*checked=\"checked\"/')
+            new \question_pattern_expectation('/name=\".*1_option0\".*value=\"1\".*checked=\"checked\"/'),
+            new \question_pattern_expectation('/name=\".*1_option1\".*value=\"1\".*checked=\"checked\"/'),
+            new \question_pattern_expectation('/name=\".*1_option2\".*value=\"2\".*checked=\"checked\"/'),
+            new \question_pattern_expectation('/name=\".*1_option3\".*value=\"2\".*checked=\"checked\"/')
         );
     }
 }


### PR DESCRIPTION
This should give you more luck in the 

Prechecker results: error
(8 errors/44 warnings) => phpcs (5/43), js (3/1),
All phpcs should disappear, I'm not the specialist for the JavaScript ones, though.

You'll have to update the Behat steps for the Moodle 4.0 navigation.
In the PHPUnit tests, do questions really have a 'idnumber' and a 'hidden' field set?
It would be worth to check this.

Best,
Luca