### PR TITLE
Fix warning of creating dynamic property

### DIFF
--- a/question.php
+++ b/question.php
@@ -47,8 +47,8 @@ class qtype_kprime_question extends question_graded_automatically_with_countback
     public $shuffleanswers;
     /** @var int numberofrows */
     public $numberofrows;
-    /** @var int numberofcols */
-    public $numberofcols;
+    /** @var int numberofcolumns */
+    public $numberofcolumns;
     /** @var array order */
     public $order = null;
     /** @var bool editedquestion */


### PR DESCRIPTION
When editing a question of type kprime the PHP warning is issued that dynamic property creation is not allowed.
My installation:
- PHP 8.2.13
- Moodle 4.5dev (Build: 20240705)