### PR TITLE
Fix exception because of require outputcomponents

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -29,8 +29,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->libdir . '/outputcomponents.php');
-
 /**
  * Subclass for generating the bits of output specific to qtype_kprime questions.
  *


### PR DESCRIPTION
 core \ exception \ coding_exception
Coding error detected, it must be fixed by a programmer: This file should not be manually included by any component.

This appears when a quiz attempt is done. Apparently the outputcomponents.php is automatically included by the core components so that the plugins should not use them anymore.

My settings:
- PHP 8.2.13
- Moodle 4.5dev (Build: 20240705)