### PR TITLE
Border around "Options and Feedback" with bg color, resolves #40.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -119,6 +119,8 @@ body#page-question-type-kprime div#fitem_id_responsetext_2 div.fitemtitle {
 }
 
 body#page-question-type-kprime div.optionbox {
+    border: 1px solid #bbb;
+    background: #eee;
     margin-top: 0;
     padding-bottom: 15px;
     padding-top: 5px;


### PR DESCRIPTION
This styles kprime as e.g. calculated (note that calculated and other have an issue at the moment see https://tracker.moodle.org/browse/MDL-84008).

<img width="2752" alt="image" src="https://github.com/user-attachments/assets/e294569c-c48f-43a5-a694-75bf4eeb010e" />
