### PR TITLE
Make changes needed after the fix of MDL-83541

### DIFF
--- a/backup/moodle2/restore_qtype_kprime_plugin.class.php
+++ b/backup/moodle2/restore_qtype_kprime_plugin.class.php
@@ -246,4 +246,111 @@ class restore_qtype_kprime_plugin extends restore_qtype_plugin {
 
         return $contents;
     }
+
+    /**
+     * Convert the backup structure of the MTF question type into a structure matching its
+     * question data. This data will then be used to produce an identity hash for comparison with
+     * questions in the database. We have to override the parent function, because we use a special
+     * structure during backup.
+     *
+     * @param array $backupdata
+     * @return stdClass
+     */
+    public static function convert_backup_to_questiondata(array $backupdata): stdClass {
+        // First, convert standard data via the parent function.
+        $questiondata = parent::convert_backup_to_questiondata($backupdata);
+
+        // Convert the row data. An array of all rows (as objects) is stored in $questiondata->options.
+        // Furthermore, there will be properties $questiondata->option_N, each containing an object with
+        // properties text (= row's optiontext field) and format (= row's optiontextformat field), with
+        // N being the row number. And finally, there is the property $questiondata->feedback_N containing
+        // each an object with the properties text (= row's optionfeedback field) and format (= row's
+        // optionfeedbackformat field), with N being the row number again.
+        foreach ($backupdata['plugin_qtype_kprime_question']['rows']['row'] as $row) {
+            $questiondata->options->rows[] = (object) $row;
+            $optionfield = 'option_' . $row['number'];
+            $feedbackfield = 'feedback_' . $row['number'];
+            $questiondata->$optionfield = (object)[
+                'text' => $row['optiontext'],
+                'format' => $row['optiontextformat'],
+            ];
+            $questiondata->$feedbackfield = (object)[
+                'text' => $row['optionfeedback'],
+                'format' => $row['optionfeedbackformat'],
+            ];
+        }
+
+        // Next step is the column data. An array of all columns (as objects) is stored in $questiondata->columns.
+        // Furthermore, for every column N, a property $questiondata->responsetext_N must be created that holds the
+        // content of the column's responstext field.
+        foreach ($backupdata['plugin_qtype_kprime_question']['columns']['column'] as $column) {
+            $questiondata->options->columns[] = (object) $column;
+            $field = 'responsetext_' . $column['number'];
+            $questiondata->$field = $column['responsetext'];
+        }
+
+        // Finally, we have to store all weights in the $questiondata->weights property. That is a
+        // two-dimensional array, built like in qtype_mtf::weight_records_to_array(). Also, for every
+        // row, we store the number of the column that has a weight > 1. This is done via the
+        // weightbutton_N property, with N being the row number.
+        $weights = [];
+        foreach ($backupdata['plugin_qtype_kprime_question']['weights']['weight'] as $weight) {
+            $weight = (object) $weight;
+            if (!array_key_exists($weight->rownumber, $weights)) {
+                $weights[$weight->rownumber] = [];
+            }
+            // weightbutton_1, weightbutton_2, ...
+            $weights[$weight->rownumber][$weight->columnnumber] = $weight;
+            if ($weight->weight > 0.0) {
+                $fieldname = 'weightbutton_' . $weight->rownumber;
+                $questiondata->$fieldname = $weight->columnnumber;
+            }
+        }
+        $questiondata->options->weights = $weights;
+
+        return $questiondata;
+    }
+
+    /**
+     * Return a list of paths to fields to be removed from questiondata before creating an identity hash.
+     * We have to remove the id and questionid property from all rows, columns and weights.
+     *
+     * @return array
+     */
+    protected function define_excluded_identity_hash_fields(): array {
+        return [
+            '/options/rows/id',
+            '/options/rows/questionid',
+            '/options/columns/id',
+            '/options/columns/questionid',
+            '/options/weights/id',
+            '/options/weights/questionid',
+        ];
+    }
+
+    /**
+     * Remove excluded fields from the questiondata structure. We use this function to remove the
+     * id and questionid fields for the weights, because they cannot be removed via the default
+     * mechanism due to the two-dimensional array. Once this is done, we call the parent function
+     * to remove the necessary fields.
+     *
+     * @param stdClass $questiondata
+     * @param array $excludefields Paths to the fields to exclude.
+     * @return stdClass The $questiondata with excluded fields removed.
+     */
+    public static function remove_excluded_question_data(stdClass $questiondata, array $excludefields = []): stdClass {
+        foreach ($questiondata->options->weights as $weightset) {
+            foreach ($weightset as $weight) {
+                if (isset($weight->id)) {
+                    unset($weight->id);
+                }
+                if (isset($weight->questionid)) {
+                    unset($weight->questionid);
+                }
+            }
+        }
+
+        return restore_qtype_plugin::remove_excluded_question_data($questiondata, $excludefields);
+    }
+
 }


### PR DESCRIPTION
With the fix of MDL-83541, Moodle will calculate a hash of all relevant fields of a question and its answers during the restore process. This allows to avoid duplicating questions during imports while still being able to distinguish different questions with the same "stamp".

This PR makes the [necessary changes](https://moodledev.io/docs/5.0/apis/plugintypes/qtype/restore).

It can be tested using the `mod/quiz/tests/backup/repeated_restore_test.php` unit tests in Moodle 4.5 and upcoming 5.0. You may want to tweak the test a bit by changing its `get_qtype_generators()` data provider and adding

```php
$generators = [
            ['kprime', 'question_one'],
            ['kprime', 'question_two'],
            ['kprime', 'question_three'],
            ['kprime', 'question_four'],
        ];
```

at the end, in order to just check this question type (instead of all installed types) and to make sure it uses all four test questions instead of just the first one.